### PR TITLE
return abstracts for non-structured articles

### DIFF
--- a/evidence_inference/preprocess/article_reader.py
+++ b/evidence_inference/preprocess/article_reader.py
@@ -152,7 +152,7 @@ class Article:
         return join_sections_on.join(out_str)
 
     def _get_abstract_keys(self):
-        return [k for k in self.article_dict.keys() if "abstract." in k]
+        return [k for k in self.article_dict.keys() if "abstract" in k]
 
     def _get_section_name(self, section_element):
         title_elements = section_element.findall("title")


### PR DESCRIPTION
Fix a bug where abstracts were not returned for articles that had
unstructed abstracts. This patch will fix this issue and return the
abstract as opposed to an empty string.